### PR TITLE
Add animated sign-in, AI review pages, and fix all ESLint errors

### DIFF
--- a/components/PretextBackground.js
+++ b/components/PretextBackground.js
@@ -1,0 +1,258 @@
+import { useEffect, useRef } from 'react';
+import { prepareWithSegments, layoutNextLine } from '@chenglou/pretext';
+
+const PHRASES = [
+  'Build lasting knowledge. ',
+  'Master concepts through active recall. ',
+  'Review smarter, not harder. ',
+  'Get instant AI feedback. ',
+  'Think deeper. Thrive faster. ',
+  'Learn anything, anywhere. ',
+  'Knowledge compounds over time. ',
+  'Small steps, massive results. ',
+];
+const TEXT = PHRASES.join('').repeat(25);
+
+const BODY_FONT = '13px Inter, sans-serif';
+const KW_FONT = 'bold 60px Inter, sans-serif';
+const LINE_HEIGHT = 21;
+const MARGIN = 36;
+const CURSOR_BASE_R = 72;
+const CURSOR_PULSE_AMP = 20;
+const KW_PAD = 20;
+
+const KW_DEFS = [
+  {
+    text: 'LEARN', color: '#00d4ff', xR: 0.12, yR: 0.18, vx: 0.28, vy: 0.18,
+  },
+  {
+    text: 'MASTER', color: '#c084fc', xR: 0.72, yR: 0.32, vx: -0.22, vy: 0.26,
+  },
+  {
+    text: 'THINK', color: '#60a5fa', xR: 0.38, yR: 0.62, vx: 0.20, vy: -0.24,
+  },
+  {
+    text: 'THRIVE', color: '#c084fc', xR: 0.65, yR: 0.76, vx: -0.26, vy: 0.16,
+  },
+  {
+    text: 'RECALL', color: '#00d4ff', xR: 0.22, yR: 0.82, vx: 0.16, vy: -0.28,
+  },
+];
+
+function getLineGeometry(y, keywords, cursor, canvasW) {
+  let xStart = MARGIN;
+  let xEnd = canvasW - MARGIN;
+
+  keywords.forEach(({
+    px, py, kw, kh,
+  }) => {
+    const halfH = kh / 2 + KW_PAD;
+    if (Math.abs(y - py) >= halfH) return;
+    const halfW = kw / 2 + KW_PAD;
+    const kLeft = px - halfW;
+    const kRight = px + halfW;
+    if (kLeft - MARGIN >= canvasW - MARGIN - kRight) {
+      xEnd = Math.min(xEnd, kLeft);
+    } else {
+      xStart = Math.max(xStart, kRight);
+    }
+  });
+
+  if (cursor) {
+    const r = cursor.r || CURSOR_BASE_R;
+    const dy = Math.abs(y - cursor.y);
+    if (dy < r) {
+      const halfChord = Math.sqrt(r * r - dy * dy) + 12;
+      const cLeft = cursor.x - halfChord;
+      const cRight = cursor.x + halfChord;
+      if (cLeft - MARGIN >= canvasW - MARGIN - cRight) {
+        xEnd = Math.min(xEnd, cLeft);
+      } else {
+        xStart = Math.max(xStart, cRight);
+      }
+    }
+  }
+
+  return { x: xStart, width: Math.max(0, xEnd - xStart) };
+}
+
+export default function PretextBackground() {
+  const canvasRef = useRef(null);
+  const cursorRef = useRef(null);
+  const ripplesRef = useRef([]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return undefined;
+    const ctx = canvas.getContext('2d');
+
+    const syncSize = () => {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    };
+    syncSize();
+    window.addEventListener('resize', syncSize);
+
+    const onMouseMove = (e) => {
+      const prev = cursorRef.current;
+      cursorRef.current = { x: e.clientX, y: e.clientY };
+      if (!prev || Math.hypot(e.clientX - prev.x, e.clientY - prev.y) > 18) {
+        ripplesRef.current.push({
+          x: e.clientX, y: e.clientY, r: 0, alpha: 0.55,
+        });
+        if (ripplesRef.current.length > 10) ripplesRef.current.shift();
+      }
+    };
+    const onMouseLeave = () => { cursorRef.current = null; };
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseleave', onMouseLeave);
+
+    // Init keywords with measured widths (done after fonts load)
+    let keywords = [];
+    let prepared = null;
+    let rafId = null;
+
+    const animate = () => {
+      const w = canvas.width;
+      const h = canvas.height;
+      ctx.clearRect(0, 0, w, h);
+
+      // Move keywords + bounce
+      for (let ki = 0; ki < keywords.length; ki++) {
+        keywords[ki].px += keywords[ki].vx;
+        keywords[ki].py += keywords[ki].vy;
+        const halfW = keywords[ki].kw / 2 + KW_PAD;
+        const halfH = keywords[ki].kh / 2 + KW_PAD;
+        if (keywords[ki].px - halfW < 0 || keywords[ki].px + halfW > w) keywords[ki].vx *= -1;
+        if (keywords[ki].py - halfH < 0 || keywords[ki].py + halfH > h) keywords[ki].vy *= -1;
+      }
+
+      // Pulsing cursor radius
+      const pulseR = CURSOR_BASE_R + Math.sin(Date.now() / 380) * CURSOR_PULSE_AMP;
+      const activeCursor = cursorRef.current ? { ...cursorRef.current, r: pulseR } : null;
+
+      // Draw body text around keywords + pulsing cursor void
+      if (prepared) {
+        ctx.font = BODY_FONT;
+        ctx.textBaseline = 'alphabetic';
+        ctx.fillStyle = 'rgba(255,255,255,0.13)';
+
+        let cursor = { segmentIndex: 0, graphemeIndex: 0 };
+        let y = MARGIN + LINE_HEIGHT;
+
+        while (y <= h + LINE_HEIGHT) {
+          const { x, width } = getLineGeometry(y, keywords, activeCursor, w);
+          if (width >= 50) {
+            const line = layoutNextLine(prepared, cursor, width);
+            if (line) {
+              ctx.fillText(line.text, x, y);
+              cursor = line.end;
+            } else {
+              cursor = { segmentIndex: 0, graphemeIndex: 0 };
+            }
+          }
+          y += LINE_HEIGHT;
+        }
+      }
+
+      // Draw expanding ripple rings
+      ripplesRef.current = ripplesRef.current.filter((rip) => rip.alpha > 0.02);
+      for (let ri = 0; ri < ripplesRef.current.length; ri++) {
+        ripplesRef.current[ri].r += 2.8;
+        ripplesRef.current[ri].alpha *= 0.93;
+        ctx.save();
+        ctx.strokeStyle = `rgba(0,212,255,${ripplesRef.current[ri].alpha * 0.7})`;
+        ctx.lineWidth = 1.2;
+        ctx.shadowBlur = 8;
+        ctx.shadowColor = 'rgba(0,212,255,0.4)';
+        ctx.beginPath();
+        ctx.arc(ripplesRef.current[ri].x, ripplesRef.current[ri].y, ripplesRef.current[ri].r, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.restore();
+      }
+
+      // Draw cursor glow dot
+      if (cursorRef.current) {
+        const { x: cx, y: cy } = cursorRef.current;
+        const dotGrad = ctx.createRadialGradient(cx, cy, 0, cx, cy, pulseR * 1.1);
+        dotGrad.addColorStop(0, 'rgba(0,212,255,0.18)');
+        dotGrad.addColorStop(0.3, 'rgba(0,212,255,0.06)');
+        dotGrad.addColorStop(1, 'rgba(0,212,255,0)');
+        ctx.fillStyle = dotGrad;
+        ctx.beginPath();
+        ctx.arc(cx, cy, pulseR * 1.1, 0, Math.PI * 2);
+        ctx.fill();
+
+        ctx.save();
+        ctx.shadowBlur = 14;
+        ctx.shadowColor = '#00d4ff';
+        ctx.fillStyle = 'rgba(0,212,255,0.85)';
+        ctx.beginPath();
+        ctx.arc(cx, cy, 4, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.restore();
+      }
+
+      // Draw keywords on top (glow + text)
+      ctx.textBaseline = 'middle';
+      keywords.forEach(({
+        text, px, py, color,
+      }) => {
+        ctx.save();
+        ctx.font = KW_FONT;
+        ctx.shadowBlur = 40;
+        ctx.shadowColor = color;
+        ctx.fillStyle = `${color}bb`;
+        ctx.fillText(text, px - ctx.measureText(text).width / 2, py);
+        ctx.restore();
+      });
+
+      rafId = requestAnimationFrame(animate);
+    };
+
+    document.fonts.ready.then(() => {
+      // Measure keyword dimensions now that fonts are loaded
+      ctx.font = KW_FONT;
+      const KW_H = 60;
+      keywords = KW_DEFS.map((def) => ({
+        text: def.text,
+        color: def.color,
+        kw: ctx.measureText(def.text).width,
+        kh: KW_H,
+        px: def.xR * canvas.width,
+        py: def.yR * canvas.height,
+        vx: def.vx,
+        vy: def.vy,
+      }));
+
+      try {
+        prepared = prepareWithSegments(TEXT, BODY_FONT);
+      } catch (e) {
+        console.warn('[PretextBackground]', e);
+      }
+      animate();
+    });
+
+    return () => {
+      window.removeEventListener('resize', syncSize);
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseleave', onMouseLeave);
+      if (rafId) cancelAnimationFrame(rafId);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        zIndex: 0,
+        pointerEvents: 'none',
+      }}
+    />
+  );
+}

--- a/components/Signin.js
+++ b/components/Signin.js
@@ -1,9 +1,12 @@
 /* eslint-disable @next/next/no-img-element */
 /* eslint-disable @next/next/no-html-link-for-pages */
 import React from 'react';
+import dynamic from 'next/dynamic';
 import { Button } from 'react-bootstrap';
 import { signIn } from '../utils/auth';
 import { useAuth } from '../utils/context/authContext';
+
+const PretextBackground = dynamic(() => import('./PretextBackground'), { ssr: false });
 
 function Signin() {
   const { signInAsGuest } = useAuth();
@@ -16,14 +19,18 @@ function Signin() {
         alignItems: 'center',
         justifyContent: 'center',
         padding: '20px',
+        position: 'relative',
       }}
     >
+      <PretextBackground />
       <div
         className="glass-card text-center"
         style={{
           width: '100%',
           maxWidth: '420px',
           padding: '48px 36px',
+          position: 'relative',
+          zIndex: 1,
         }}
       >
         <img

--- a/components/TestMode.js
+++ b/components/TestMode.js
@@ -217,6 +217,12 @@ TestMode.propTypes = {
   cards: PropTypes.arrayOf(PropTypes.shape({
     type: PropTypes.string.isRequired,
     firebaseKey: PropTypes.string.isRequired,
+    imageUrl: PropTypes.string,
+    picture: PropTypes.string,
+    question: PropTypes.string,
+    title: PropTypes.string,
+    answer: PropTypes.string,
+    taskSteps: PropTypes.string,
   })).isRequired,
 };
 

--- a/components/conceptual-proceduralInstructionsModal.js
+++ b/components/conceptual-proceduralInstructionsModal.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import { Button, Modal } from 'react-bootstrap';
 
 const conceptualSteps = [
@@ -108,6 +109,17 @@ function StepCard({ step, index, accent }) {
   );
 }
 
+StepCard.propTypes = {
+  step: PropTypes.shape({
+    icon: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    tip: PropTypes.string.isRequired,
+  }).isRequired,
+  index: PropTypes.number.isRequired,
+  accent: PropTypes.string.isRequired,
+};
+
 function SectionHeader({ emoji, label, accent }) {
   return (
     <div style={{
@@ -133,6 +145,12 @@ function SectionHeader({ emoji, label, accent }) {
     </div>
   );
 }
+
+SectionHeader.propTypes = {
+  emoji: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  accent: PropTypes.string.isRequired,
+};
 
 function InstructionConceptualAndProceduralModal() {
   const [show, setShow] = useState(false);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     ]
   },
   "dependencies": {
+    "@chenglou/pretext": "^0.0.6",
     "axios": "^0.21.1",
     "bootstrap": "^5.1.3",
     "dotenv": "^16.4.5",

--- a/pages/conceptual-knowledge/[firebaseKey].js
+++ b/pages/conceptual-knowledge/[firebaseKey].js
@@ -2,6 +2,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { useRouter } from 'next/router';
 import Link from 'next/link';
+import PropTypes from 'prop-types';
 import { Button, Container } from 'react-bootstrap';
 import { useState, useEffect } from 'react';
 import ConceptualCard from '../../components/conceptualCard';
@@ -81,6 +82,11 @@ function CardDeck({ total, onTestMode }) {
     </div>
   );
 }
+
+CardDeck.propTypes = {
+  total: PropTypes.number.isRequired,
+  onTestMode: PropTypes.func.isRequired,
+};
 
 function ConceptualKnowledgePage() {
   const router = useRouter();

--- a/pages/conceptual-knowledge/review/[firebaseKey].js
+++ b/pages/conceptual-knowledge/review/[firebaseKey].js
@@ -3,7 +3,94 @@ import { useRouter } from 'next/router';
 import axios from 'axios';
 import { useEffect, useRef, useState } from 'react';
 import { Button } from 'react-bootstrap';
+import PropTypes from 'prop-types';
 import { getSingleConceptualKnowledge } from '../../../api/conceptualknowledgeData';
+
+const ACCENT = '#00d4ff';
+const STEPS = ['Question', 'Your Answer', 'AI Review'];
+
+function ReviewStepper({ current }) {
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      padding: '14px 24px',
+      background: 'rgba(0,0,0,0.15)',
+      borderBottom: '1px solid rgba(255,255,255,0.06)',
+    }}
+    >
+      {STEPS.map((label, i) => {
+        const done = i < current;
+        const active = i === current;
+        let circleBg = 'rgba(255,255,255,0.06)';
+        if (done) circleBg = ACCENT;
+        else if (active) circleBg = 'rgba(0,212,255,0.15)';
+
+        let circleColor = 'rgba(255,255,255,0.3)';
+        if (done) circleColor = '#0a0a1a';
+        else if (active) circleColor = ACCENT;
+
+        let labelColor = 'rgba(255,255,255,0.25)';
+        if (active) labelColor = ACCENT;
+        else if (done) labelColor = 'rgba(0,212,255,0.6)';
+
+        return (
+          <div key={label} style={{ display: 'flex', alignItems: 'center', flex: i < STEPS.length - 1 ? 1 : 'none' }}>
+            <div style={{
+              display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '5px',
+            }}
+            >
+              <div style={{
+                width: '28px',
+                height: '28px',
+                borderRadius: '50%',
+                background: circleBg,
+                border: `2px solid ${done || active ? ACCENT : 'rgba(255,255,255,0.15)'}`,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: '0.72rem',
+                fontWeight: '700',
+                color: circleColor,
+                transition: 'all 0.3s ease',
+                flexShrink: 0,
+              }}
+              >
+                {done ? '✓' : i + 1}
+              </div>
+              <span style={{
+                fontSize: '0.58rem',
+                fontWeight: '600',
+                textTransform: 'uppercase',
+                letterSpacing: '0.6px',
+                color: labelColor,
+                whiteSpace: 'nowrap',
+                transition: 'color 0.3s ease',
+              }}
+              >
+                {label}
+              </span>
+            </div>
+            {i < STEPS.length - 1 && (
+              <div style={{
+                flex: 1,
+                height: '2px',
+                margin: '0 8px',
+                marginBottom: '22px',
+                background: done ? ACCENT : 'rgba(255,255,255,0.08)',
+                borderRadius: '1px',
+                transition: 'background 0.4s ease',
+              }}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+ReviewStepper.propTypes = { current: PropTypes.number.isRequired };
 
 function ReviewConceptualKnowledge() {
   const router = useRouter();
@@ -14,11 +101,18 @@ function ReviewConceptualKnowledge() {
   const [loading, setLoading] = useState(false);
   const [answered, setAnswered] = useState(false);
   const bottomRef = useRef(null);
+  const uidRef = useRef(0);
+
+  let currentStep = 0;
+  if (answered && loading) currentStep = 1;
+  else if (answered) currentStep = 2;
 
   useEffect(() => {
     getSingleConceptualKnowledge(firebaseKey).then((response) => {
       setConceptualCard(response);
-      setMessages([{ role: 'bot', type: 'question', content: response.question }]);
+      setMessages([{
+        role: 'bot', type: 'question', content: response.question, uid: 0,
+      }]);
     });
   }, []);
 
@@ -27,7 +121,10 @@ function ReviewConceptualKnowledge() {
   }, [messages, loading]);
 
   const pushMessage = (role, content, type = 'text') => {
-    setMessages((prev) => [...prev, { role, content, type }]);
+    uidRef.current += 1;
+    setMessages((prev) => [...prev, {
+      role, content, type, uid: uidRef.current,
+    }]);
   };
 
   const handleSend = async () => {
@@ -65,7 +162,9 @@ function ReviewConceptualKnowledge() {
   };
 
   const handleReset = () => {
-    setMessages([{ role: 'bot', type: 'question', content: conceptualCard.question }]);
+    setMessages([{
+      role: 'bot', type: 'question', content: conceptualCard.question, uid: 0,
+    }]);
     setAnswered(false);
     setInput('');
   };
@@ -90,8 +189,8 @@ function ReviewConceptualKnowledge() {
 
   const getLabelFor = (role, type) => {
     if (role === 'user') return { text: 'Your Answer', color: '#c084fc' };
-    if (type === 'question') return { text: 'Question', color: '#00d4ff' };
-    if (type === 'answer') return { text: 'Correct Answer', color: '#00d4ff' };
+    if (type === 'question') return { text: 'Question', color: ACCENT };
+    if (type === 'answer') return { text: 'Correct Answer', color: ACCENT };
     if (type === 'feedback') return { text: 'AI Feedback', color: '#a78bfa' };
     if (type === 'example') return { text: 'Example & Tip', color: '#667eea' };
     return null;
@@ -108,13 +207,12 @@ function ReviewConceptualKnowledge() {
         minHeight: '540px',
       }}
       >
-
         {/* Header */}
         <div style={{
           background: 'rgba(255,255,255,0.07)',
           backdropFilter: 'blur(16px)',
           border: '1px solid rgba(0,212,255,0.25)',
-          borderBottom: '1px solid rgba(255,255,255,0.08)',
+          borderBottom: 'none',
           borderRadius: '16px 16px 0 0',
           padding: '14px 18px',
           display: 'flex',
@@ -134,12 +232,11 @@ function ReviewConceptualKnowledge() {
               fontSize: '1rem',
               flexShrink: 0,
             }}
-            >
-              ◆
+            >◆
             </div>
             <div>
               <div style={{
-                fontSize: '0.68rem', fontWeight: '700', color: '#00d4ff', letterSpacing: '1px', textTransform: 'uppercase',
+                fontSize: '0.68rem', fontWeight: '700', color: ACCENT, letterSpacing: '1px', textTransform: 'uppercase',
               }}
               >Conceptual Review
               </div>
@@ -148,6 +245,9 @@ function ReviewConceptualKnowledge() {
           </div>
           <Button className="glass-btn-outline" size="sm" onClick={handleClose}>← Back</Button>
         </div>
+
+        {/* Stepper */}
+        <ReviewStepper current={currentStep} />
 
         {/* Chat window */}
         <div style={{
@@ -163,11 +263,11 @@ function ReviewConceptualKnowledge() {
           gap: '18px',
         }}
         >
-          {messages.map((msg, i) => {
+          {messages.map((msg) => {
             const label = getLabelFor(msg.role, msg.type);
             const isUser = msg.role === 'user';
             return (
-              <div key={i} style={{ display: 'flex', flexDirection: 'column', alignItems: isUser ? 'flex-end' : 'flex-start' }}>
+              <div key={msg.uid} style={{ display: 'flex', flexDirection: 'column', alignItems: isUser ? 'flex-end' : 'flex-start' }}>
                 {label && (
                   <span style={{
                     fontSize: '0.63rem',
@@ -179,8 +279,7 @@ function ReviewConceptualKnowledge() {
                     paddingLeft: isUser ? 0 : '4px',
                     paddingRight: isUser ? '4px' : 0,
                   }}
-                  >
-                    {label.text}
+                  >{label.text}
                   </span>
                 )}
                 <div style={isUser ? {
@@ -194,8 +293,7 @@ function ReviewConceptualKnowledge() {
                   background: 'rgba(192,132,252,0.18)',
                   border: '1px solid rgba(192,132,252,0.4)',
                 } : getBotBubbleStyle(msg.type)}
-                >
-                  {msg.content}
+                >{msg.content}
                 </div>
               </div>
             );
@@ -216,14 +314,14 @@ function ReviewConceptualKnowledge() {
                 {[0, 1, 2].map((d) => (
                   <div
                     key={d}
+                    className="typing-dot"
                     style={{
                       width: '7px',
                       height: '7px',
                       borderRadius: '50%',
-                      background: '#00d4ff',
+                      background: ACCENT,
                       animationDelay: `${d * 0.2}s`,
                     }}
-                    className="typing-dot"
                   />
                 ))}
               </div>
@@ -246,10 +344,9 @@ function ReviewConceptualKnowledge() {
             <div style={{ display: 'flex', gap: '10px', alignItems: 'flex-end' }}>
               <textarea
                 rows={3}
-                placeholder="Write your answer from memory… (Enter to send, Shift+Enter for newline)"
+                placeholder="Write your answer from memory… use Enter for new lines"
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
-                onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSend(); } }}
                 className="glass-input"
                 style={{
                   flex: 1, resize: 'none', borderRadius: '10px', padding: '10px 14px', fontSize: '0.9rem',
@@ -276,16 +373,6 @@ function ReviewConceptualKnowledge() {
         </div>
       </div>
 
-      <style jsx>{`
-        .typing-dot {
-          animation: typingBounce 1.2s ease-in-out infinite;
-        }
-        @keyframes typingBounce {
-          0%, 60%, 100% { transform: translateY(0); opacity: 0.6; }
-          30% { transform: translateY(-6px); opacity: 1; }
-        }
-      `}
-      </style>
     </div>
   );
 }

--- a/pages/procedural-knowledge/review/[firebaseKey].js
+++ b/pages/procedural-knowledge/review/[firebaseKey].js
@@ -3,24 +3,116 @@
 import { useRouter } from 'next/router';
 import { useEffect, useRef, useState } from 'react';
 import axios from 'axios';
+import PropTypes from 'prop-types';
 import { Button } from 'react-bootstrap';
 import { getProceduralKnowledgeByFirebaseKey } from '../../../api/proceduralknowledgeData';
+
+const ACCENT = '#c084fc';
+const STEPPER_LABELS = ['Task', 'Your Steps', 'AI Review'];
+
+function getCircleStyle(done, active) {
+  if (done) return { background: ACCENT, border: `2px solid ${ACCENT}`, color: '#0a0a1a' };
+  if (active) return { background: 'rgba(192,132,252,0.15)', border: `2px solid ${ACCENT}`, color: ACCENT };
+  return { background: 'rgba(255,255,255,0.06)', border: '2px solid rgba(255,255,255,0.15)', color: 'rgba(255,255,255,0.3)' };
+}
+
+function ReviewStepper({ current }) {
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      padding: '14px 24px',
+      background: 'rgba(0,0,0,0.15)',
+      borderBottom: '1px solid rgba(255,255,255,0.06)',
+    }}
+    >
+      {STEPPER_LABELS.map((label, i) => {
+        const done = i < current;
+        const active = i === current;
+        const circleStyle = getCircleStyle(done, active);
+        let labelColor = 'rgba(255,255,255,0.25)';
+        if (active) labelColor = ACCENT;
+        else if (done) labelColor = 'rgba(192,132,252,0.6)';
+        return (
+          <div key={label} style={{ display: 'flex', alignItems: 'center', flex: i < STEPPER_LABELS.length - 1 ? 1 : 'none' }}>
+            <div style={{
+              display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '5px',
+            }}
+            >
+              <div style={{
+                width: '28px',
+                height: '28px',
+                borderRadius: '50%',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: '0.72rem',
+                fontWeight: '700',
+                flexShrink: 0,
+                transition: 'all 0.3s ease',
+                ...circleStyle,
+              }}
+              >
+                {done ? '✓' : i + 1}
+              </div>
+              <span style={{
+                fontSize: '0.58rem',
+                fontWeight: '600',
+                textTransform: 'uppercase',
+                letterSpacing: '0.6px',
+                whiteSpace: 'nowrap',
+                transition: 'color 0.3s ease',
+                color: labelColor,
+              }}
+              >
+                {label}
+              </span>
+            </div>
+            {i < STEPPER_LABELS.length - 1 && (
+              <div style={{
+                flex: 1,
+                height: '2px',
+                margin: '0 8px',
+                marginBottom: '22px',
+                borderRadius: '1px',
+                transition: 'background 0.4s ease',
+                background: done ? ACCENT : 'rgba(255,255,255,0.08)',
+              }}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+ReviewStepper.propTypes = { current: PropTypes.number.isRequired };
 
 const ProceduralCardKnowledgeReviewPage = () => {
   const router = useRouter();
   const { firebaseKey } = router.query;
   const [proceduralCard, setProceduralCard] = useState({});
   const [messages, setMessages] = useState([]);
-  const [input, setInput] = useState('');
+  const [steps, setSteps] = useState([]);
+  const [stepInput, setStepInput] = useState('');
   const [loading, setLoading] = useState(false);
   const [answered, setAnswered] = useState(false);
   const bottomRef = useRef(null);
+  const inputRef = useRef(null);
+  const uidRef = useRef(0);
+
+  const stepCount = steps.length;
+
+  let currentStep = 0;
+  if (answered && !loading) currentStep = 2;
+  else if (answered || stepCount > 0) currentStep = 1;
 
   useEffect(() => {
     getProceduralKnowledgeByFirebaseKey(firebaseKey).then((response) => {
       setProceduralCard(response);
       setMessages([{
-        role: 'bot', type: 'task', content: response.title, picture: response.picture,
+        role: 'bot', type: 'task', content: response.title, picture: response.picture, uid: 0,
       }]);
     });
   }, []);
@@ -29,22 +121,36 @@ const ProceduralCardKnowledgeReviewPage = () => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, loading]);
 
-  const pushMessage = (role, content, type = 'text') => {
-    setMessages((prev) => [...prev, { role, content, type }]);
+  const pushMessage = (role, content, type) => {
+    uidRef.current += 1;
+    setMessages((prev) => [...prev, {
+      role, content, type, uid: uidRef.current,
+    }]);
   };
 
-  const handleSend = async () => {
-    if (!input.trim() || loading || answered) return;
-    const userSteps = input.trim();
-    setInput('');
+  const handleAddStep = () => {
+    if (!stepInput.trim() || answered) return;
+    const text = stepInput.trim();
+    setSteps((prev) => [...prev, text]);
+    pushMessage('user', text, 'step');
+    setStepInput('');
+    inputRef.current?.focus();
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') { e.preventDefault(); handleAddStep(); }
+  };
+
+  const handleSubmit = async () => {
+    if (stepCount === 0 || loading || answered) return;
     setAnswered(true);
-    pushMessage('user', userSteps, 'user-steps');
     setLoading(true);
+    const combined = steps.map((s, i) => `${i + 1}. ${s}`).join('\n');
 
     try {
       const feedbackRes = await axios.post('/api/openai', {
         model: 'gpt-4o-mini',
-        prompt: `Considering the task of '${proceduralCard.title}', you've outlined these steps: '${userSteps}'. Let's take a closer look together to see if anything might have been missed or could be tweaked for better clarity or efficiency. After reviewing, I'll suggest a revised set of steps that includes any improvements or additional actions needed to complete the task more effectively. Remember, it's all about making the process as smooth and straightforward as possible for you.`,
+        prompt: `Considering the task of '${proceduralCard.title}', you've outlined these steps:\n${combined}\n\nLet's take a closer look together to see if anything might have been missed or could be tweaked for better clarity or efficiency. After reviewing, I'll suggest a revised set of steps that includes any improvements or additional actions needed to complete the task more effectively.`,
         max_tokens: 600,
       });
 
@@ -59,10 +165,11 @@ const ProceduralCardKnowledgeReviewPage = () => {
 
   const handleReset = () => {
     setMessages([{
-      role: 'bot', type: 'task', content: proceduralCard.title, picture: proceduralCard.picture,
+      role: 'bot', type: 'task', content: proceduralCard.title, picture: proceduralCard.picture, uid: 0,
     }]);
+    setSteps([]);
+    setStepInput('');
     setAnswered(false);
-    setInput('');
   };
 
   const handleClose = () => router.push(`/conceptual-knowledge/${proceduralCard.pathId}`);
@@ -83,12 +190,15 @@ const ProceduralCardKnowledgeReviewPage = () => {
   };
 
   const getLabelFor = (role, type) => {
-    if (role === 'user') return { text: 'Your Steps', color: '#00d4ff' };
-    if (type === 'task') return { text: 'Task', color: '#c084fc' };
-    if (type === 'steps') return { text: 'Correct Steps', color: '#c084fc' };
+    if (role === 'user') return { text: 'Your Step', color: '#00d4ff' };
+    if (type === 'task') return { text: 'Task', color: ACCENT };
+    if (type === 'steps') return { text: 'Correct Steps', color: ACCENT };
     if (type === 'feedback') return { text: 'AI Feedback', color: '#a78bfa' };
     return null;
   };
+
+  // Count step number for a given message index
+  const getStepNum = (upToIndex) => messages.slice(0, upToIndex + 1).filter((m) => m.type === 'step').length;
 
   return (
     <div style={{ display: 'flex', justifyContent: 'center', padding: '20px 16px' }}>
@@ -101,13 +211,12 @@ const ProceduralCardKnowledgeReviewPage = () => {
         minHeight: '540px',
       }}
       >
-
         {/* Header */}
         <div style={{
           background: 'rgba(255,255,255,0.07)',
           backdropFilter: 'blur(16px)',
           border: '1px solid rgba(192,132,252,0.25)',
-          borderBottom: '1px solid rgba(255,255,255,0.08)',
+          borderBottom: 'none',
           borderRadius: '16px 16px 0 0',
           padding: '14px 18px',
           display: 'flex',
@@ -132,15 +241,19 @@ const ProceduralCardKnowledgeReviewPage = () => {
             </div>
             <div>
               <div style={{
-                fontSize: '0.68rem', fontWeight: '700', color: '#c084fc', letterSpacing: '1px', textTransform: 'uppercase',
+                fontSize: '0.68rem', fontWeight: '700', color: ACCENT, letterSpacing: '1px', textTransform: 'uppercase',
               }}
-              >Procedural Review
+              >
+                Procedural Review
               </div>
               <div style={{ fontSize: '0.8rem', color: 'rgba(255,255,255,0.5)' }}>AI-powered study session</div>
             </div>
           </div>
           <Button className="glass-btn-outline" size="sm" onClick={handleClose}>← Back</Button>
         </div>
+
+        {/* Stepper */}
+        <ReviewStepper current={currentStep} />
 
         {/* Chat window */}
         <div style={{
@@ -153,7 +266,7 @@ const ProceduralCardKnowledgeReviewPage = () => {
           padding: '20px 16px',
           display: 'flex',
           flexDirection: 'column',
-          gap: '18px',
+          gap: '14px',
         }}
         >
           {messages.map((msg, i) => {
@@ -162,10 +275,16 @@ const ProceduralCardKnowledgeReviewPage = () => {
 
             if (msg.type === 'task') {
               return (
-                <div key={i} style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
+                <div key={msg.uid} style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
                   {label && (
                     <span style={{
-                      fontSize: '0.63rem', fontWeight: '700', textTransform: 'uppercase', letterSpacing: '1px', color: label.color, marginBottom: '5px', paddingLeft: '4px',
+                      fontSize: '0.63rem',
+                      fontWeight: '700',
+                      textTransform: 'uppercase',
+                      letterSpacing: '1px',
+                      color: label.color,
+                      marginBottom: '5px',
+                      paddingLeft: '4px',
                     }}
                     >
                       {label.text}
@@ -195,15 +314,70 @@ const ProceduralCardKnowledgeReviewPage = () => {
                       {msg.content}
                     </div>
                     <div style={{ padding: '0 18px 14px', fontSize: '0.82rem', color: 'rgba(255,255,255,0.5)' }}>
-                      Try to recall the steps for this task from memory.
+                      Recall the steps for this task one by one.
                     </div>
                   </div>
                 </div>
               );
             }
 
+            if (msg.type === 'step') {
+              const num = getStepNum(i);
+              return (
+                <div key={msg.uid} style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end' }}>
+                  <span style={{
+                    fontSize: '0.63rem',
+                    fontWeight: '700',
+                    textTransform: 'uppercase',
+                    letterSpacing: '1px',
+                    color: '#00d4ff',
+                    marginBottom: '5px',
+                    paddingRight: '4px',
+                  }}
+                  >
+                    Step
+                    {' '}
+                    {num}
+                  </span>
+                  <div style={{
+                    maxWidth: '78%',
+                    padding: '12px 18px',
+                    borderRadius: '18px 18px 4px 18px',
+                    fontSize: '0.95rem',
+                    lineHeight: 1.6,
+                    color: 'white',
+                    background: 'rgba(0,212,255,0.12)',
+                    border: '1px solid rgba(0,212,255,0.3)',
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    gap: '10px',
+                  }}
+                  >
+                    <span style={{
+                      flexShrink: 0,
+                      width: '22px',
+                      height: '22px',
+                      borderRadius: '50%',
+                      background: 'rgba(0,212,255,0.25)',
+                      border: '1px solid rgba(0,212,255,0.5)',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      fontSize: '0.7rem',
+                      fontWeight: '700',
+                      color: '#00d4ff',
+                    }}
+                    >
+                      {num}
+                    </span>
+                    <span>{msg.content}</span>
+                  </div>
+                </div>
+              );
+            }
+
             return (
-              <div key={i} style={{ display: 'flex', flexDirection: 'column', alignItems: isUser ? 'flex-end' : 'flex-start' }}>
+              <div key={msg.uid} style={{ display: 'flex', flexDirection: 'column', alignItems: isUser ? 'flex-end' : 'flex-start' }}>
                 {label && (
                   <span style={{
                     fontSize: '0.63rem',
@@ -252,14 +426,14 @@ const ProceduralCardKnowledgeReviewPage = () => {
                 {[0, 1, 2].map((d) => (
                   <div
                     key={d}
+                    className="typing-dot"
                     style={{
                       width: '7px',
                       height: '7px',
                       borderRadius: '50%',
-                      background: '#c084fc',
+                      background: ACCENT,
                       animationDelay: `${d * 0.2}s`,
                     }}
-                    className="typing-dot"
                   />
                 ))}
               </div>
@@ -279,26 +453,63 @@ const ProceduralCardKnowledgeReviewPage = () => {
         }}
         >
           {!answered ? (
-            <div style={{ display: 'flex', gap: '10px', alignItems: 'flex-end' }}>
-              <textarea
-                rows={4}
-                placeholder="Type the steps you remember… (Enter to send, Shift+Enter for newline)"
-                value={input}
-                onChange={(e) => setInput(e.target.value)}
-                onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); handleSend(); } }}
-                className="glass-input"
-                style={{
-                  flex: 1, resize: 'none', borderRadius: '10px', padding: '10px 14px', fontSize: '0.9rem',
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <span style={{
+                  fontSize: '0.65rem',
+                  fontWeight: '700',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.8px',
+                  color: '#00d4ff',
                 }}
-              />
-              <Button
-                className="glass-btn"
-                onClick={handleSend}
-                disabled={!input.trim() || loading}
-                style={{ padding: '12px 22px', borderRadius: '10px', flexShrink: 0 }}
-              >
-                Send →
-              </Button>
+                >
+                  Step
+                  {' '}
+                  {stepCount + 1}
+                </span>
+                <div style={{ flex: 1, height: '1px', background: 'rgba(0,212,255,0.2)' }} />
+              </div>
+              <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+                <input
+                  ref={inputRef}
+                  type="text"
+                  placeholder={`Describe step ${stepCount + 1}…`}
+                  value={stepInput}
+                  onChange={(e) => setStepInput(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  className="glass-input"
+                  style={{
+                    flex: 1, borderRadius: '10px', padding: '10px 14px', fontSize: '0.9rem',
+                  }}
+                />
+                <Button
+                  className="glass-btn-outline"
+                  onClick={handleAddStep}
+                  disabled={!stepInput.trim()}
+                  style={{
+                    borderRadius: '10px', padding: '10px 18px', flexShrink: 0, fontWeight: '600',
+                  }}
+                >
+                  + Add
+                </Button>
+              </div>
+              {stepCount > 0 && (
+                <Button
+                  className="glass-btn"
+                  onClick={handleSubmit}
+                  disabled={loading}
+                  style={{ width: '100%', padding: '11px', borderRadius: '10px' }}
+                >
+                  Submit
+                  {' '}
+                  {stepCount}
+                  {' '}
+                  Step
+                  {stepCount !== 1 ? 's' : ''}
+                  {' '}
+                  for Review →
+                </Button>
+              )}
             </div>
           ) : (
             <div style={{
@@ -312,16 +523,6 @@ const ProceduralCardKnowledgeReviewPage = () => {
         </div>
       </div>
 
-      <style jsx>{`
-        .typing-dot {
-          animation: typingBounce 1.2s ease-in-out infinite;
-        }
-        @keyframes typingBounce {
-          0%, 60%, 100% { transform: translateY(0); opacity: 0.6; }
-          30% { transform: translateY(-6px); opacity: 1; }
-        }
-      `}
-      </style>
     </div>
   );
 };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -442,3 +442,14 @@ a {
   background-color: rgba(255, 255, 255, 0.15) !important;
   border-color: rgba(255, 255, 255, 0.3) !important;
 }
+
+/* ── Chat typing indicator ───────────────────────────────── */
+
+.typing-dot {
+  animation: typingBounce 1.2s ease-in-out infinite;
+}
+
+@keyframes typingBounce {
+  0%, 60%, 100% { transform: translateY(0); opacity: 0.6; }
+  30% { transform: translateY(-6px); opacity: 1; }
+}


### PR DESCRIPTION
## Summary

- **Animated sign-in page**: Added `PretextBackground` canvas component using `@chenglou/pretext` — kinetic keywords (LEARN, MASTER, THINK, THRIVE, RECALL) drift and bounce, body text flows around them, cursor creates a pulsing void with ripple rings and a glow dot
- **AI review pages redesign**: Both conceptual and procedural review pages rebuilt as chat-style UIs with a 3-step progress stepper (Question → Your Answer → AI Review)
- **Procedural review UX**: Each step is typed individually and appears as a numbered chat bubble; a "Submit N Step(s) for Review" button triggers AI feedback once at least one step is added
- **OpenAI model**: Switched to `gpt-4o-mini` (cheapest capable model); API route now respects the `model` field from the request body
- **ESLint fixes**: Resolved all errors that were blocking Netlify deployment — `no-nested-ternary`, `no-array-index-key`, `no-param-reassign`, `consistent-return`, unknown `jsx` property, and missing `PropTypes` across multiple components

## Test plan

- [ ] Sign out and verify the animated canvas appears behind the sign-in card; move the cursor and confirm ripple rings and glow dot render
- [ ] Sign in and open a conceptual card → click Review → verify 3-step stepper advances as you type and submit your answer
- [ ] Open a procedural card → click Review → add steps one by one, confirm numbered bubbles appear, click Submit and verify AI feedback
- [ ] Run `npm run lint` and confirm only warnings (no errors)
- [ ] Run `npm run build` and confirm it completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)