### PR TITLE
Fix broken images + add welcome screen for new/guest users

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -55,16 +55,15 @@ export default function NavBar() {
             </Link>
           </Nav>
           <Nav style={{ alignItems: 'center', gap: '12px' }}>
-            {user?.photoURL && (
-              <Image
-                src={user.photoURL}
-                alt="User avatar"
-                roundedCircle
-                style={{
-                  height: '32px', width: '32px', border: '2px solid rgba(255,255,255,0.3)',
-                }}
-              />
-            )}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={user?.photoURL || '/placeholder-avatar.svg'}
+              alt="User avatar"
+              onError={(e) => { e.target.src = '/placeholder-avatar.svg'; }}
+              style={{
+                height: '32px', width: '32px', borderRadius: '50%', border: '2px solid rgba(255,255,255,0.3)', objectFit: 'cover',
+              }}
+            />
             <Link passHref href="/">
               <Button className="glass-btn-outline" onClick={signOut} size="sm">
                 Sign Out

--- a/components/TestMode.js
+++ b/components/TestMode.js
@@ -98,6 +98,7 @@ function TestMode({ cards }) {
           <img
             src={card.imageUrl || card.picture}
             alt={card.question || card.title}
+            onError={(e) => { e.target.src = '/placeholder-image.svg'; }}
             style={{
               width: '100%', height: '260px', objectFit: 'cover', display: 'block',
             }}

--- a/components/WelcomeScreen.js
+++ b/components/WelcomeScreen.js
@@ -1,0 +1,101 @@
+/* eslint-disable @next/next/no-img-element */
+import PropTypes from 'prop-types';
+import { Button } from 'react-bootstrap';
+
+const features = [
+  {
+    icon: '🗺️',
+    title: 'Create Learning Paths',
+    desc: 'Organize any topic into a structured path with a goal and cover image.',
+  },
+  {
+    icon: '🧠',
+    title: 'Build Knowledge Cards',
+    desc: 'Add Conceptual cards (Q&A) and Procedural cards (step-by-step tasks).',
+  },
+  {
+    icon: '🤖',
+    title: 'Review with AI',
+    desc: 'Get AI-powered feedback on your answers to deepen your understanding.',
+  },
+];
+
+export default function WelcomeScreen({ onDone }) {
+  return (
+    <div style={{
+      minHeight: '100vh',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: '24px 16px',
+    }}
+    >
+      <div style={{ maxWidth: '520px', width: '100%', textAlign: 'center' }}>
+
+        {/* Logo + name */}
+        <div style={{ marginBottom: '24px' }}>
+          <img
+            src="/thinkthrive.png"
+            alt="ThinkThrive"
+            style={{
+              width: '72px', height: '72px', borderRadius: '16px', marginBottom: '16px',
+            }}
+          />
+          <h1 style={{
+            fontWeight: '800', fontSize: '2rem', color: 'white', marginBottom: '8px',
+          }}
+          >
+            Welcome to ThinkThrive
+          </h1>
+          <p style={{ color: 'rgba(255,255,255,0.55)', fontSize: '1rem' }}>
+            Learn smarter with neuroscience-based learning paths
+          </p>
+        </div>
+
+        {/* Feature cards */}
+        <div
+          style={{
+            display: 'flex', flexDirection: 'column', gap: '12px', marginBottom: '32px',
+          }}
+        >
+          {features.map(({ icon, title, desc }) => (
+            <div
+              key={title}
+              className="glass-card"
+              style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: '16px',
+                padding: '16px 20px',
+                textAlign: 'left',
+              }}
+            >
+              <span style={{ fontSize: '1.8rem', flexShrink: 0 }}>{icon}</span>
+              <div>
+                <p style={{
+                  fontWeight: '700', fontSize: '0.95rem', color: 'white', margin: '0 0 4px',
+                }}
+                >
+                  {title}
+                </p>
+                <p style={{ fontSize: '0.83rem', color: 'rgba(255,255,255,0.55)', margin: 0 }}>{desc}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <Button
+          className="glass-btn"
+          style={{ padding: '12px 40px', fontSize: '1rem', fontWeight: '700' }}
+          onClick={onDone}
+        >
+          Get Started →
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+WelcomeScreen.propTypes = {
+  onDone: PropTypes.func.isRequired,
+};

--- a/components/WelcomeScreen.js
+++ b/components/WelcomeScreen.js
@@ -20,7 +20,7 @@ const features = [
   },
 ];
 
-export default function WelcomeScreen({ onDone }) {
+export default function WelcomeScreen({ onDone, isGuest }) {
   return (
     <div style={{
       minHeight: '100vh',
@@ -84,6 +84,17 @@ export default function WelcomeScreen({ onDone }) {
           ))}
         </div>
 
+        {isGuest && (
+          <p style={{
+            fontSize: '0.8rem',
+            color: 'rgba(255,255,255,0.4)',
+            marginBottom: '16px',
+          }}
+          >
+            As a guest you can create paths and cards — your data will be saved for this session.
+          </p>
+        )}
+
         <Button
           className="glass-btn"
           style={{ padding: '12px 40px', fontSize: '1rem', fontWeight: '700' }}
@@ -98,4 +109,9 @@ export default function WelcomeScreen({ onDone }) {
 
 WelcomeScreen.propTypes = {
   onDone: PropTypes.func.isRequired,
+  isGuest: PropTypes.bool,
+};
+
+WelcomeScreen.defaultProps = {
+  isGuest: false,
 };

--- a/components/conceptualCard.js
+++ b/components/conceptualCard.js
@@ -60,6 +60,7 @@ function ConceptualCard({ conceptualCard, onUpdate, userID }) {
           src={conceptualCard.imageUrl}
           alt={conceptualCard.question}
           className="flashcard-image"
+          onError={(e) => { e.target.src = '/placeholder-image.svg'; }}
         />
       ) : (
         <div style={{

--- a/components/pathCard.js
+++ b/components/pathCard.js
@@ -36,6 +36,7 @@ function PathCard({ path, onUpdate, size }) {
       <img
         src={userPhoto}
         alt={madeBy}
+        onError={(e) => { e.target.src = '/placeholder-avatar.svg'; }}
         style={{
           width: '28px',
           height: '28px',
@@ -60,6 +61,7 @@ function PathCard({ path, onUpdate, size }) {
         <img
           src={path.image}
           alt={path.title}
+          onError={(e) => { e.target.src = '/placeholder-image.svg'; }}
           style={{
             position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover',
           }}
@@ -130,6 +132,7 @@ function PathCard({ path, onUpdate, size }) {
         <img
           src={path.image}
           alt={path.title}
+          onError={(e) => { e.target.src = '/placeholder-image.svg'; }}
           style={{
             width: '42%', objectFit: 'cover', flexShrink: 0, borderRadius: '16px 0 0 16px',
           }}
@@ -179,6 +182,7 @@ function PathCard({ path, onUpdate, size }) {
         <img
           src={path.image}
           alt={path.title}
+          onError={(e) => { e.target.src = '/placeholder-image.svg'; }}
           style={{
             width: '100%', height: '100%', objectFit: 'cover', borderRadius: '16px 16px 0 0',
           }}

--- a/components/pathCard.js
+++ b/components/pathCard.js
@@ -34,7 +34,7 @@ function PathCard({ path, onUpdate, size }) {
   const creator = (
     <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
       <img
-        src={userPhoto}
+        src={userPhoto || '/placeholder-avatar.svg'}
         alt={madeBy}
         onError={(e) => { e.target.src = '/placeholder-avatar.svg'; }}
         style={{

--- a/components/proceduralCard.js
+++ b/components/proceduralCard.js
@@ -47,6 +47,7 @@ function ProceduralCard({ proceduralCard, onUpdate, userID }) {
           src={proceduralCard.picture}
           alt={proceduralCard.title}
           className="flashcard-image"
+          onError={(e) => { e.target.src = '/placeholder-image.svg'; }}
         />
       ) : (
         <div style={{

--- a/public/placeholder-avatar.svg
+++ b/public/placeholder-avatar.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="32" fill="#2a3a4a"/>
+  <circle cx="32" cy="24" r="10" fill="rgba(255,255,255,0.3)"/>
+  <path d="M12 56 Q12 40 32 40 Q52 40 52 56" fill="rgba(255,255,255,0.3)"/>
+</svg>

--- a/public/placeholder-image.svg
+++ b/public/placeholder-image.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300" viewBox="0 0 400 300">
+  <rect width="400" height="300" fill="#1e2a3a"/>
+  <rect x="150" y="100" width="100" height="80" rx="8" fill="none" stroke="rgba(255,255,255,0.2)" stroke-width="2"/>
+  <circle cx="175" cy="125" r="10" fill="rgba(255,255,255,0.2)"/>
+  <polyline points="150,170 180,140 210,155 240,125 270,170" fill="rgba(255,255,255,0.1)" stroke="rgba(255,255,255,0.2)" stroke-width="2"/>
+  <text x="200" y="215" text-anchor="middle" fill="rgba(255,255,255,0.3)" font-family="sans-serif" font-size="13">No image</text>
+</svg>

--- a/utils/ViewDirector.js
+++ b/utils/ViewDirector.js
@@ -1,12 +1,31 @@
 /* eslint-disable @next/next/no-img-element */
+import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useAuth } from './context/authContext';
 import Loading from '../components/Loading';
 import Signin from '../components/Signin';
 import NavBar from '../components/NavBar';
+import WelcomeScreen from '../components/WelcomeScreen';
 
 const ViewDirectorBasedOnUserAuthStatus = ({ component: Component, pageProps }) => {
   const { user, userLoading } = useAuth();
+  const [showWelcome, setShowWelcome] = useState(false);
+
+  useEffect(() => {
+    if (!user) return;
+    if (user.isAnonymous) {
+      setShowWelcome(true);
+    } else if (!localStorage.getItem('hasSeenWelcome')) {
+      setShowWelcome(true);
+    }
+  }, [user]);
+
+  const handleDone = () => {
+    if (!user?.isAnonymous) {
+      localStorage.setItem('hasSeenWelcome', 'true');
+    }
+    setShowWelcome(false);
+  };
 
   // if user state is null, then show loader
   if (userLoading) {
@@ -15,6 +34,9 @@ const ViewDirectorBasedOnUserAuthStatus = ({ component: Component, pageProps }) 
 
   // what the user should see if they are logged in
   if (user) {
+    if (showWelcome) {
+      return <WelcomeScreen onDone={handleDone} />;
+    }
     return (
       <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
         <NavBar /> {/* NavBar only visible if user is logged in and is in every view */}

--- a/utils/ViewDirector.js
+++ b/utils/ViewDirector.js
@@ -35,7 +35,7 @@ const ViewDirectorBasedOnUserAuthStatus = ({ component: Component, pageProps }) 
   // what the user should see if they are logged in
   if (user) {
     if (showWelcome) {
-      return <WelcomeScreen onDone={handleDone} />;
+      return <WelcomeScreen onDone={handleDone} isGuest={user.isAnonymous} />;
     }
     return (
       <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>


### PR DESCRIPTION
## Summary
- Add `onError` fallback placeholders for all broken path, card, and profile images
- Add `placeholder-image.svg` and `placeholder-avatar.svg` to `/public`
- Show avatar placeholder when user has no profile picture (null src)
- Add full-page welcome screen shown after first login with feature highlights
- Guest users see welcome screen every session; Google users see it once (localStorage)
- Guest users see a note explaining they can create paths and cards

## Test plan
- [ ] Sign in as Guest → welcome screen appears with guest note
- [ ] Click "Get Started" → app loads normally
- [ ] Sign in with Google → welcome screen appears once, not again on refresh
- [ ] Browse paths with broken images → placeholder image shown instead of broken icon
- [ ] Cards with no profile picture → avatar placeholder shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)