### PR TITLE
Improve Create Path form + restore GA, SEO, and personal links

### DIFF
--- a/components/GoogleAnalytics.js
+++ b/components/GoogleAnalytics.js
@@ -1,0 +1,24 @@
+import Script from 'next/script';
+
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+
+export default function GoogleAnalytics() {
+  if (!GA_MEASUREMENT_ID) return null;
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="google-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${GA_MEASUREMENT_ID}');
+        `}
+      </Script>
+    </>
+  );
+}

--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -55,6 +55,25 @@ export default function NavBar() {
             </Link>
           </Nav>
           <Nav style={{ alignItems: 'center', gap: '12px' }}>
+            <a
+              href="https://www.frankcampos.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                color: 'rgba(255,255,255,0.6)', fontSize: '0.85rem', fontWeight: '500', textDecoration: 'none',
+              }}
+            >
+              by Frank Campos
+            </a>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <a href="https://www.linkedin.com/in/frank-parada-campos-214a48229/" target="_blank" rel="noopener noreferrer" style={{ opacity: 0.7 }}>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src="https://cdn.icon-icons.com/icons2/2428/PNG/512/linkedin_black_logo_icon_147114.png" alt="LinkedIn" style={{ width: '22px', height: '22px', filter: 'invert(1)' }} />
+            </a>
+            <a href="https://github.com/frankcampos" target="_blank" rel="noopener noreferrer" style={{ opacity: 0.7 }}>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src="https://cdn-icons-png.flaticon.com/512/25/25231.png" alt="GitHub" style={{ width: '22px', height: '22px', filter: 'invert(1)' }} />
+            </a>
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src={user?.photoURL || '/placeholder-avatar.svg'}

--- a/components/forms/FormPath.js
+++ b/components/forms/FormPath.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import Form from 'react-bootstrap/Form';
 import Button from 'react-bootstrap/Button';
 import { useRouter } from 'next/router';
@@ -16,33 +16,52 @@ const initialState = {
 
 function FormPath({ objPath }) {
   const [formState, setFormState] = useState(initialState);
+  const [previewUrl, setPreviewUrl] = useState('');
+  const [uploading, setUploading] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef(null);
   const { user } = useAuth();
   const router = useRouter();
   const storage = firebase.storage();
 
   useEffect(() => {
-    if (objPath.firebaseKey) setFormState({ ...objPath });
+    if (objPath.firebaseKey) {
+      setFormState({ ...objPath });
+      setPreviewUrl(objPath.image || '');
+    }
   }, [objPath]);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
-    setFormState((prevState) => ({ ...prevState, [name]: value }));
+    setFormState((prev) => ({ ...prev, [name]: value }));
   };
 
-  const handleImageChange = async (e) => {
+  const uploadFile = async (file) => {
+    if (!file || !file.type.startsWith('image/')) return;
+    setUploading(true);
+    setPreviewUrl(URL.createObjectURL(file));
     try {
-      if (e.target.files[0]) {
-        const imageFile = e.target.files[0];
-        const storageRef = storage.ref();
-        const imageRef = storageRef.child(`images/${imageFile.name}`);
-        await imageRef.put(imageFile);
-        const url = await imageRef.getDownloadURL();
-        setFormState((prevState) => ({ ...prevState, image: url }));
-      }
+      const imageRef = storage.ref().child(`images/${Date.now()}_${file.name}`);
+      await imageRef.put(file);
+      const url = await imageRef.getDownloadURL();
+      setFormState((prev) => ({ ...prev, image: url }));
+      setPreviewUrl(url);
     } catch (error) {
-      console.error('Error uploading image or getting download URL:', error);
+      console.error('Error uploading image:', error);
+    } finally {
+      setUploading(false);
     }
   };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    setIsDragging(false);
+    const file = e.dataTransfer.files[0];
+    uploadFile(file);
+  };
+
+  const handleDragOver = (e) => { e.preventDefault(); setIsDragging(true); };
+  const handleDragLeave = () => setIsDragging(false);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -70,60 +89,151 @@ function FormPath({ objPath }) {
       <h2 style={{
         fontWeight: '700',
         fontSize: '1.5rem',
-        marginBottom: '28px',
-        color: 'white',
+        marginBottom: '4px',
+        color: '#00d4ff',
         textAlign: 'center',
       }}
       >
         {objPath.firebaseKey ? 'Update' : 'Create'} Learning Path
       </h2>
+      <p style={{
+        textAlign: 'center', color: 'rgba(255,255,255,0.4)', fontSize: '0.85rem', marginBottom: '28px',
+      }}
+      >
+        {objPath.firebaseKey ? 'Edit your path details below' : 'Fill in the details to start your learning journey'}
+      </p>
 
-      <Form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      <Form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+
+        {/* Title */}
         <div>
-          <Form.Label style={{ color: 'rgba(255,255,255,0.7)', fontSize: '0.85rem', marginBottom: '6px' }}>Title</Form.Label>
+          <Form.Label style={{ color: 'rgba(255,255,255,0.7)', fontSize: '0.85rem', marginBottom: '6px' }}>
+            Title
+          </Form.Label>
           <Form.Control
             type="text"
-            placeholder="Enter Title"
+            placeholder="e.g. Becoming a Web Developer"
             name="title"
             value={formState.title}
             onChange={handleChange}
             className="glass-input"
+            required
           />
         </div>
 
+        {/* Drag & Drop image upload */}
         <div>
-          <Form.Label style={{ color: 'rgba(255,255,255,0.7)', fontSize: '0.85rem', marginBottom: '6px' }}>Image URL or Upload Image</Form.Label>
-          <Form.Control
-            type="text"
-            name="image"
-            value={formState.image}
-            onChange={handleChange}
-            placeholder="Enter the URL of an image"
-            className="glass-input"
-            style={{ marginBottom: '8px' }}
-          />
-          <Form.Control
+          <Form.Label style={{ color: 'rgba(255,255,255,0.7)', fontSize: '0.85rem', marginBottom: '6px' }}>
+            Cover Image
+          </Form.Label>
+
+          {/* Drop zone */}
+          <div
+            role="button"
+            tabIndex={0}
+            onClick={() => fileInputRef.current.click()}
+            onKeyDown={(e) => e.key === 'Enter' && fileInputRef.current.click()}
+            onDrop={handleDrop}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            style={{
+              border: `2px dashed ${isDragging ? '#00d4ff' : 'rgba(255,255,255,0.2)'}`,
+              borderRadius: '12px',
+              padding: '28px 16px',
+              textAlign: 'center',
+              cursor: 'pointer',
+              background: isDragging ? 'rgba(0,212,255,0.07)' : 'rgba(255,255,255,0.04)',
+              transition: 'border-color 0.2s ease, background 0.2s ease',
+            }}
+          >
+            {uploading ? (
+              <p style={{ color: '#00d4ff', margin: 0, fontSize: '0.9rem' }}>Uploading...</p>
+            ) : (
+              <>
+                <div style={{ fontSize: '2rem', marginBottom: '8px' }}>🖼️</div>
+                <p style={{ color: 'rgba(255,255,255,0.6)', margin: '0 0 4px', fontSize: '0.9rem' }}>
+                  Drag & drop an image here
+                </p>
+                <p style={{ color: 'rgba(255,255,255,0.35)', margin: 0, fontSize: '0.78rem' }}>
+                  or click to browse files
+                </p>
+              </>
+            )}
+          </div>
+
+          {/* Hidden file input */}
+          <input
+            ref={fileInputRef}
             type="file"
-            name="imageFile"
-            onChange={handleImageChange}
-            className="glass-input"
+            accept="image/*"
+            style={{ display: 'none' }}
+            onChange={(e) => uploadFile(e.target.files[0])}
           />
+
+          {/* Preview */}
+          {previewUrl && !uploading && (
+            <div style={{ marginTop: '12px', position: 'relative' }}>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={previewUrl}
+                alt="Preview"
+                style={{
+                  width: '100%',
+                  height: '160px',
+                  objectFit: 'cover',
+                  borderRadius: '10px',
+                  border: '1px solid rgba(255,255,255,0.15)',
+                }}
+              />
+              <button
+                type="button"
+                onClick={() => { setPreviewUrl(''); setFormState((prev) => ({ ...prev, image: '' })); }}
+                style={{
+                  position: 'absolute',
+                  top: '8px',
+                  right: '8px',
+                  background: 'rgba(0,0,0,0.6)',
+                  border: 'none',
+                  borderRadius: '50%',
+                  width: '28px',
+                  height: '28px',
+                  color: 'white',
+                  cursor: 'pointer',
+                  fontSize: '0.8rem',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                ✕
+              </button>
+            </div>
+          )}
         </div>
 
+        {/* Goal */}
         <div>
-          <Form.Label style={{ color: 'rgba(255,255,255,0.7)', fontSize: '0.85rem', marginBottom: '6px' }}>Goal</Form.Label>
+          <Form.Label style={{ color: 'rgba(255,255,255,0.7)', fontSize: '0.85rem', marginBottom: '6px' }}>
+            Goal
+          </Form.Label>
           <Form.Control
             type="text"
-            placeholder="Enter Goal"
+            placeholder="What will you be able to do after completing this path?"
             name="goal"
             value={formState.goal}
             onChange={handleChange}
             className="glass-input"
+            required
           />
         </div>
 
-        <div style={{ display: 'flex', justifyContent: 'center', marginTop: '8px' }}>
-          <Button className="glass-btn" type="submit">
+        <div style={{ display: 'flex', justifyContent: 'center', marginTop: '4px' }}>
+          <Button
+            className="glass-btn"
+            type="submit"
+            disabled={uploading}
+            style={{ padding: '10px 40px', fontSize: '0.95rem', fontWeight: '600' }}
+          >
             {objPath.firebaseKey ? 'Update Path' : 'Create Path'}
           </Button>
         </div>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,20 +1,45 @@
 /* eslint-disable react/prop-types */
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import Head from 'next/head';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import '../styles/globals.css';
 import { AuthProvider } from '../utils/context/authContext';
 import ViewDirectorBasedOnUserAuthStatus from '../utils/ViewDirector';
+import GoogleAnalytics from '../components/GoogleAnalytics';
 
 function MyApp({ Component, pageProps }) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleRouteChange = (url) => {
+      if (typeof window.gtag !== 'undefined') {
+        window.gtag('event', 'page_view', { page_path: url });
+      }
+    };
+    router.events.on('routeChangeComplete', handleRouteChange);
+    return () => router.events.off('routeChangeComplete', handleRouteChange);
+  }, [router.events]);
+
   return (
-    <AuthProvider> {/* gives children components access to user and auth methods */}
-      <ViewDirectorBasedOnUserAuthStatus
-        // if status is pending === loading
-        // if status is logged in === view app
-        // if status is logged out === sign in page
-        component={Component}
-        pageProps={pageProps}
-      />
-    </AuthProvider>
+    <>
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="description" content="ThinkThrive — a neuroscience-based learning platform to build and share structured learning paths." />
+        <meta property="og:title" content="ThinkThrive" />
+        <meta property="og:description" content="Build and share neuroscience-based learning paths." />
+        <meta property="og:type" content="website" />
+        <meta name="author" content="Frank Campos" />
+        <title>ThinkThrive</title>
+      </Head>
+      <GoogleAnalytics />
+      <AuthProvider>
+        <ViewDirectorBasedOnUserAuthStatus
+          component={Component}
+          pageProps={pageProps}
+        />
+      </AuthProvider>
+    </>
   );
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { Button, Container } from 'react-bootstrap';
 import Link from 'next/link';
+import Head from 'next/head';
 import { useEffect, useState } from 'react';
 import { getAllPaths } from '../api/pathsData';
 import PathCard from '../components/pathCard';
@@ -23,6 +24,10 @@ function Home() {
 
   return (
     <Container>
+      <Head>
+        <title>Learning Paths | ThinkThrive</title>
+        <meta name="description" content="Explore community-created neuroscience-based learning paths on ThinkThrive." />
+      </Head>
       <div style={{ textAlign: 'center', marginBottom: '32px' }}>
         <h1 style={{
           fontWeight: '700', fontSize: '2rem', color: 'white', marginBottom: '6px',

--- a/pages/path/new.js
+++ b/pages/path/new.js
@@ -2,8 +2,7 @@ import FormPath from '../../components/forms/FormPath';
 
 function New() {
   return (
-    <div>
-      <h1 style={{ color: 'white' }}>Create New Learning Path</h1>
+    <div style={{ padding: '16px 0' }}>
       <FormPath />
     </div>
   );

--- a/utils/ViewDirector.js
+++ b/utils/ViewDirector.js
@@ -61,6 +61,14 @@ const ViewDirectorBasedOnUserAuthStatus = ({ component: Component, pageProps }) 
             display: 'flex', justifyContent: 'center', gap: '16px', alignItems: 'center',
           }}
           >
+            <a
+              href="https://www.frankcampos.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: 'rgba(255,255,255,0.6)', fontSize: '0.85rem', fontWeight: '500', textDecoration: 'none' }}
+            >
+              Built by Frank Campos
+            </a>
             <a href="https://www.linkedin.com/in/frank-parada-campos-214a48229/" target="_blank" rel="noopener noreferrer" style={{ opacity: 0.7 }}>
               <img src="https://cdn.icon-icons.com/icons2/2428/PNG/512/linkedin_black_logo_icon_147114.png" alt="LinkedIn" style={{ width: '28px', height: '28px', filter: 'invert(1)' }} />
             </a>


### PR DESCRIPTION
## Summary
- Replace URL input + native file button with styled drag-and-drop image upload zone
- Add live image preview with remove button after upload
- Move form title inside card with cyan accent and subtitle helper text
- Improve Goal field placeholder text
- Disable submit button while image is uploading
- Restore Google Analytics and pageview tracking (lost in previous merge)
- Restore SEO meta tags and OpenGraph tags in `_app.js`
- Restore "by Frank Campos" + LinkedIn/GitHub icons in navbar and footer

## Test plan
- [ ] Go to `/path/new` — drag an image onto the drop zone, preview should appear
- [ ] Click the drop zone to browse and select a file
- [ ] Click ✕ on preview to remove the image
- [ ] Submit button should be disabled while uploading
- [ ] Navbar shows "by Frank Campos" with LinkedIn and GitHub icons
- [ ] Footer shows "Built by Frank Campos" with icons
- [ ] Browser tab shows "Learning Paths | ThinkThrive"
- [ ] GA Realtime dashboard shows active user when browsing the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)