### PR TITLE
Add path privacy — public/private toggle

### DIFF
--- a/components/forms/FormPath.js
+++ b/components/forms/FormPath.js
@@ -12,6 +12,7 @@ const initialState = {
   title: '',
   image: '',
   goal: '',
+  public: true,
 };
 
 function FormPath({ objPath }) {
@@ -227,6 +228,37 @@ function FormPath({ objPath }) {
           />
         </div>
 
+        {/* Privacy toggle */}
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '14px 16px',
+          borderRadius: '10px',
+          background: 'rgba(255,255,255,0.04)',
+          border: '1px solid rgba(255,255,255,0.1)',
+        }}
+        >
+          <div>
+            <p style={{
+              color: 'rgba(255,255,255,0.85)', fontWeight: '600', fontSize: '0.88rem', margin: '0 0 2px',
+            }}
+            >
+              {formState.public !== false ? '🌐 Public' : '🔒 Private'}
+            </p>
+            <p style={{ color: 'rgba(255,255,255,0.4)', fontSize: '0.78rem', margin: 0 }}>
+              {formState.public !== false ? 'Visible to everyone on the home page' : 'Only accessible via direct link'}
+            </p>
+          </div>
+          <Form.Check
+            type="switch"
+            id="public-switch"
+            checked={formState.public !== false}
+            onChange={(e) => setFormState((prev) => ({ ...prev, public: e.target.checked }))}
+            style={{ transform: 'scale(1.2)', cursor: 'pointer' }}
+          />
+        </div>
+
         <div style={{ display: 'flex', justifyContent: 'center', marginTop: '4px' }}>
           <Button
             className="glass-btn"
@@ -247,6 +279,8 @@ FormPath.propTypes = {
     firebaseKey: PropTypes.string,
     image: PropTypes.string,
     title: PropTypes.string,
+    goal: PropTypes.string,
+    public: PropTypes.bool,
   }),
 };
 

--- a/components/pathCard.js
+++ b/components/pathCard.js
@@ -15,6 +15,24 @@ function PathCard({ path, onUpdate, size }) {
   const userPhoto = user.uid === path.user_id ? user.photoURL : path.user_photo;
   const isOwner = user.uid === path.user_id;
 
+  const privateBadge = path.public === false && isOwner ? (
+    <span style={{
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: '4px',
+      fontSize: '0.7rem',
+      fontWeight: '600',
+      color: 'rgba(255,255,255,0.6)',
+      background: 'rgba(255,255,255,0.1)',
+      padding: '2px 8px',
+      borderRadius: '12px',
+      border: '1px solid rgba(255,255,255,0.15)',
+    }}
+    >
+      🔒 Private
+    </span>
+  ) : null;
+
   const actions = (
     <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
       <Link href={`/conceptual-knowledge/${path.firebaseKey}`} passHref>
@@ -79,16 +97,23 @@ function PathCard({ path, onUpdate, size }) {
         }}
         >
           <div style={{
-            display: 'inline-block',
-            fontSize: '0.7rem',
-            fontWeight: '700',
-            textTransform: 'uppercase',
-            letterSpacing: '1px',
-            color: '#00d4ff',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
             marginBottom: '8px',
           }}
           >
-            Featured
+            <div style={{
+              fontSize: '0.7rem',
+              fontWeight: '700',
+              textTransform: 'uppercase',
+              letterSpacing: '1px',
+              color: '#00d4ff',
+            }}
+            >
+              Featured
+            </div>
+            {privateBadge}
           </div>
           <h2 style={{
             fontWeight: '800', fontSize: '1.6rem', color: 'white', marginBottom: '8px', lineHeight: 1.2,
@@ -142,12 +167,21 @@ function PathCard({ path, onUpdate, size }) {
         }}
         >
           <div>
-            <h3 style={{
-              fontWeight: '700', fontSize: '1.1rem', color: 'white', marginBottom: '8px', lineHeight: 1.3,
+            <div style={{
+              display: 'flex',
+              alignItems: 'flex-start',
+              gap: '8px',
+              marginBottom: '8px',
             }}
             >
-              {path.title}
-            </h3>
+              <h3 style={{
+                fontWeight: '700', fontSize: '1.1rem', color: 'white', margin: 0, lineHeight: 1.3,
+              }}
+              >
+                {path.title}
+              </h3>
+              {privateBadge}
+            </div>
             <p style={{
               fontSize: '0.83rem',
               color: 'rgba(255,255,255,0.6)',
@@ -203,7 +237,7 @@ function PathCard({ path, onUpdate, size }) {
           fontWeight: '700',
           fontSize: '0.92rem',
           color: 'white',
-          marginBottom: '6px',
+          marginBottom: '4px',
           display: '-webkit-box',
           WebkitLineClamp: 2,
           WebkitBoxOrient: 'vertical',
@@ -212,6 +246,7 @@ function PathCard({ path, onUpdate, size }) {
         >
           {path.title}
         </h4>
+        {privateBadge && <div style={{ marginBottom: '4px' }}>{privateBadge}</div>}
         <div style={{
           display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: '6px',
         }}
@@ -243,6 +278,7 @@ PathCard.propTypes = {
     user_id: PropTypes.string,
     user_name: PropTypes.string,
     user_photo: PropTypes.string,
+    public: PropTypes.bool,
   }).isRequired,
   onUpdate: PropTypes.func.isRequired,
   size: PropTypes.oneOf(['featured', 'wide', 'default']),

--- a/pages/index.js
+++ b/pages/index.js
@@ -17,7 +17,7 @@ function Home() {
   const [paths, setPaths] = useState([]);
 
   const getAllThePaths = () => {
-    getAllPaths().then((response) => setPaths(response));
+    getAllPaths().then((response) => setPaths(response.filter((p) => p.public !== false)));
   };
 
   useEffect(() => { getAllThePaths(); }, []);


### PR DESCRIPTION
## Summary
- Adds a public/private toggle to the Create/Edit Path form (defaults to public)
- Home page feed now filters out private paths so they're hidden from everyone
- PathCard shows a 🔒 Private badge to the owner across all card sizes (featured, wide, default)
- Anyone with a direct link can still view a private path (no auth gate on view pages)

## Test plan
- [ ] Create a new path — toggle should default to public (🌐)
- [ ] Flip toggle to private (🔒) and save — path should disappear from home feed
- [ ] Go to My Paths — private path should still appear there
- [ ] Direct link to private path should still open normally
- [ ] 🔒 Private badge should appear on the card only for the owner, not other users

🤖 Generated with [Claude Code](https://claude.com/claude-code)